### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Atom Dark Theme (for Emacs)
 ===========================
 
-This is a port of the Atom Dark theme from [Atom.io](https://atom.io/).  For comparision, please view the following:
+This is a port of the Atom Dark theme from [Atom.io](https://atom.io/).  For comparison, please view the following:
 
 * [Atom Dark UI Theme](https://atom.io/themes/atom-dark-ui)
 * [Atom Dark Syntax Theme](https://atom.io/themes/atom-dark-syntax)


### PR DESCRIPTION
@whitlockjc, I've corrected a typographical error in the documentation of the [atom-dark-theme-emacs](https://github.com/whitlockjc/atom-dark-theme-emacs) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
