### PR TITLE
Add support for company-mode

### DIFF
--- a/atom-dark-theme.el
+++ b/atom-dark-theme.el
@@ -161,6 +161,17 @@
  '(whitespace-space-before-tab ((t (:inherit (whitespace-empty)))))
  '(whitespace-tab ((t (:inherit (whitespace-empty)))))
  '(whitespace-trailing ((t (:inherit (trailing-whitespace)))))
+
+ ;; company
+ '(company-preview ((t (:foreground "#96CBFE"))))
+ '(company-preview-common ((t (:inherit company-preview :underline "#96CBFE"))))
+ '(company-preview-search ((t (:inherit company-preview))))
+ '(company-scrollbar-bg ((t (:inherit company-tooltip :background "dim grey"))))
+ '(company-scrollbar-fg ((t (:background "black"))))
+ '(company-tooltip ((t (:background "#c5c8c6" :foreground "#1d1f21"))))
+ '(company-tooltip-common ((t (:inherit company-tooltip :foreground "red4"))))
+ '(company-tooltip-common-selection ((t (:inherit company-tooltip-selection :background "#96CBFE"))))
+ '(company-tooltip-selection ((t (:inherit company-tooltip :background "#96CBFE"))))
  )
 
 (defvar atom-dark-theme-force-faces-for-mode t


### PR DESCRIPTION
This PR adds support for `company-mode`. 

I borrowed the code from this [tuned version of `atom-dark-theme`](https://github.com/kevroletin/.spacemacs.d/blob/f09983b3052f7367ef577e7f86f6e342f719b6dd/.spacemacs.d/user-theme/local/atom-dark-tuned-theme/atom-dark-tuned-theme.el) written by @kevroletin.

Here is what it looks like in `elisp` mode:

![capture d ecran 2018-10-22 a 12 14 36](https://user-images.githubusercontent.com/95471/47288306-de6a1c80-d5f5-11e8-8cdc-47a47869f774.png)

